### PR TITLE
Category Bar 슬라이드 동작 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,3 +50,8 @@
         @apply bg-background text-foreground;
     }
 }
+
+.carousel-grid {
+    @apply grid grid-cols-carousel gap-4 items-center;
+    grid-template-areas: "carousel_prev_btn carousel_container carousel_next_btn";
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,32 @@ export default function Home() {
                 <SearchTabs />
             </header>
 
-            <main></main>
+            <main className={'px-10'}>
+                <section
+                    id={'main_category'}
+                    className={'flex gap-6 py-6 h-20 items-center w-full mt-6'}
+                >
+                    <CategoryBar />
+                    <FilterButton />
+                </section>
+
+                <section
+                    id={'main_list'}
+                    className={'grid grid-cols-5 grid-rows-5 gap-4 mt-5'}
+                >
+                    {Array.from({ length: 40 }).map((_, idx) => (
+                        <a key={idx} className={'w-full h-full'}>
+                            <Image
+                                width={500}
+                                height={500}
+                                objectFit={'cover'}
+                                src={'/mockHouse.svg'}
+                                alt={'mockHouse'}
+                            />
+                        </a>
+                    ))}
+                </section>
+            </main>
             <footer></footer>
         </>
     )

--- a/src/components/CategoryBar/__test__/CategoryBar.test.tsx
+++ b/src/components/CategoryBar/__test__/CategoryBar.test.tsx
@@ -1,0 +1,10 @@
+import { CategoryBar } from '@/components/CategoryBar'
+import { render, screen } from '@testing-library/react'
+
+describe('CategoryBar', () => {
+    it('should render the CartegoryBar component', () => {
+        render(<CategoryBar />)
+        const categoryBar = screen.getByRole('list')
+        expect(categoryBar).toBeInTheDocument()
+    })
+})

--- a/src/components/CategoryBar/index.tsx
+++ b/src/components/CategoryBar/index.tsx
@@ -1,0 +1,26 @@
+import fs from 'fs'
+import path from 'path'
+import Image from 'next/image'
+import { Carousel } from '@/components/ui/Carousel/Carousel'
+
+export const CategoryBar = () => {
+    //TODO : icon과 title을 매칭하여 같이 렌더링 해줘야 한다.
+    const categoryIconDir = path.join(process.cwd(), '/public/category_icons')
+    const categoryIcons = fs.readdirSync(categoryIconDir)
+
+    return (
+        <div>
+            <Carousel>
+                {categoryIcons.map((icon, idx) => (
+                    <Image
+                        key={idx}
+                        src={`/category_icons/${icon}`}
+                        width={48}
+                        height={48}
+                        alt={icon}
+                    />
+                ))}
+            </Carousel>
+        </div>
+    )
+}

--- a/src/components/Icons/LeftArrow.tsx
+++ b/src/components/Icons/LeftArrow.tsx
@@ -1,0 +1,9 @@
+import { SVGIcon, SVGIconProps } from '@/components/ui/SVGIcon'
+
+export const LeftArrow = (props: SVGIconProps) => {
+    return (
+        <SVGIcon viewBox={'0 0 32 32'} {...props}>
+            <path fill="none" d="M20 28 8.7 16.7a1 1 0 0 1 0-1.4L20 4"></path>
+        </SVGIcon>
+    )
+}

--- a/src/components/Icons/RightArrow.tsx
+++ b/src/components/Icons/RightArrow.tsx
@@ -1,0 +1,14 @@
+import { SVGIcon, SVGIconProps } from '@/components/ui/SVGIcon'
+
+export const RightArrow = (props: SVGIconProps) => {
+    return (
+        <SVGIcon viewBox={'0 0 12 12'} {...props}>
+            <path
+                d="M4.5 1.5L8.7375 5.7375C8.80621 5.8076 8.8447 5.90184 8.8447 6C8.8447 6.09816 8.80621 6.1924 8.7375 6.2625L4.5 10.5"
+                stroke="black"
+                strokeWidth="2"
+                fill="none"
+            />
+        </SVGIcon>
+    )
+}

--- a/src/components/ui/Carousel/Carousel.tsx
+++ b/src/components/ui/Carousel/Carousel.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useState } from 'react'
+import { CarouselItemProps, CrouselProps } from '@/components/ui/Carousel/types'
+
+/**
+ *
+ * Carousel Component
+ * @param offset  한 슬라이드에 표시할 아이템의 수
+ * @param children
+ * @constructor
+ * TODO : prev, next 예외 처리, ui 개선  및 외부 에서 컨트롤 할 수 있는 요소 들로 변경 (width, height 등)
+ */
+
+const Carousel = ({ children }: CrouselProps) => {
+    const [currentSlide, setCurrentSlide] = useState<number>(1)
+    const childArray = Array.isArray(children) ? children : [children]
+
+    const handleNext = () => {
+        setCurrentSlide((prev) => prev + 1)
+    }
+
+    const handlePrev = () => {
+        setCurrentSlide((prev) => prev - 1)
+    }
+
+    return (
+        <div
+            className={'carousel-grid carousel_container relative'}
+            ref={carouselContainerRef}
+        >
+            <div className={'area-carousel_container overflow-hidden gap-10'}>
+                <div
+                    ref={carouselTrackRef}
+                    className={'flex gap-6'}
+                    style={{
+                        display: 'grid',
+                        gridAutoFlow: 'column',
+                        // gridTemplateColumns: ' repeat(auto-fill, 47px)',
+                        gridAutoColumns: '47px',
+                        transform: `translateX(-${translateX}px)`,
+                    }}
+                >
+                    {childArray.map((child, idx) => (
+                        <Carousel.Item key={idx}>{child}</Carousel.Item>
+                    ))}
+                </div>
+            </div>
+            <button
+                className={
+                    'area-carousel_prev_btn flex justify-center items-center w-7 h-7 rounded-full border border-1 border-gray-20'
+                }
+                onClick={handleOnPrev}
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 32 32"
+                    width="12px"
+                    height="12px"
+                    aria-hidden="true"
+                    role="presentation"
+                    focusable="false"
+                >
+                    <path
+                        fill="none"
+                        d="M20 28 8.7 16.7a1 1 0 0 1 0-1.4L20 4"
+                        stroke="black"
+                        strokeWidth="5"
+                    ></path>
+                </svg>
+            </button>
+            <button
+                className={
+                    'area-carousel_next_btn flex justify-center items-center w-7 h-7 rounded-full border border-1 border-gray-200'
+                }
+                onClick={handleOnNext}
+            >
+                <svg
+                    width="12px"
+                    height="12px"
+                    viewBox="0 0 12 12"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path
+                        d="M4.5 1.5L8.7375 5.7375C8.80621 5.8076 8.8447 5.90184 8.8447 6C8.8447 6.09816 8.80621 6.1924 8.7375 6.2625L4.5 10.5"
+                        stroke="black"
+                        strokeWidth="2"
+                    />
+                </svg>
+            </button>
+        </div>
+    )
+}
+
+const CarouselItem = ({ children }: CarouselItemProps) => {
+    return <div>{children}</div>
+}
+
+Carousel.Item = CarouselItem
+
+export { Carousel }

--- a/src/components/ui/Carousel/Carousel.tsx
+++ b/src/components/ui/Carousel/Carousel.tsx
@@ -12,6 +12,7 @@ import {
     CrouselProps,
     DEFAULT_OFFSET,
 } from '@/components/ui/Carousel/types'
+import { useCarousel } from '@/components/ui/Carousel/useCarousel'
 
 /**
  *
@@ -24,72 +25,17 @@ import {
 
 const Carousel = ({ slidesToShow, slidesToScroll, children }: CrouselProps) => {
     const childArray = Array.isArray(children) ? children : [children]
-    const [firstVisibleSlideIndex, setFirstVisibleSlideIndex] =
-        useState<number>(DEFAULT_OFFSET)
-
-    const [currentTransitionX, setCurrentTransitionX] = useState<number>(0)
-
-    const carouselTrackRef = useRef<HTMLUListElement>(null)
-    const slideDisplayInfo = useRef<{
-        slidesToShow: number
-        slidesToScroll: number
-    }>({ slidesToShow: -1, slidesToScroll: -1 })
-
-    const individualSlideWidthRef = useRef<number>(0)
-    const carouselItemRef = useRef<HTMLLIElement>(null)
-
-    useEffect(() => {
-        if (carouselTrackRef.current && carouselItemRef.current) {
-            const carouselTrackWidth = carouselTrackRef.current.clientWidth
-            const computedStyle = getComputedStyle(carouselTrackRef.current)
-            let gapValue = computedStyle.gap || computedStyle.columnGap || '0px'
-
-            if (gapValue === 'normal') gapValue = '0px'
-
-            individualSlideWidthRef.current =
-                carouselItemRef.current.clientWidth + parseInt(gapValue)
-            slideDisplayInfo.current.slidesToShow =
-                slidesToShow ||
-                Math.floor(carouselTrackWidth / individualSlideWidthRef.current)
-
-            slideDisplayInfo.current.slidesToScroll =
-                slideDisplayInfo.current.slidesToShow > 2
-                    ? slideDisplayInfo.current.slidesToShow - 1
-                    : slideDisplayInfo.current.slidesToShow
-        }
-    }, [firstVisibleSlideIndex, slidesToScroll, slidesToShow])
-
-    const handleOnPrev = useCallback(() => {
-        if (carouselTrackRef.current) {
-            const currenX = Math.abs(
-                carouselTrackRef.current.getBoundingClientRect().x
-            )
-            const nextPosition =
-                slideDisplayInfo.current.slidesToScroll *
-                individualSlideWidthRef.current
-
-            // setCurrentTransitionX((prev) => Math.max(0, prev - nextPosition))
-            const translateX = Math.max(0, currenX - nextPosition)
-            carouselTrackRef.current.style.transform = `translateX(-${translateX}px)`
-        }
-    }, [])
-
-    const handleOnNext = useCallback(() => {
-        if (carouselTrackRef.current) {
-            const currentX = Math.abs(
-                carouselTrackRef.current.getBoundingClientRect().x
-            )
-            const maxScrollPosition =
-                childArray.length * individualSlideWidthRef.current -
-                carouselTrackRef.current.clientWidth
-            const nextPosition =
-                currentX +
-                slideDisplayInfo.current.slidesToScroll *
-                    individualSlideWidthRef.current
-            const nextTranslateX = Math.min(nextPosition, maxScrollPosition)
-            carouselTrackRef.current.style.transform = `translateX(-${nextTranslateX}px)`
-        }
-    }, [])
+    const {
+        currentTransitionX,
+        carouselTrackRef,
+        carouselItemRef,
+        handleOnPrev,
+        handleOnNext,
+    } = useCarousel({
+        slidesToShow,
+        slidesToScroll,
+        childArray,
+    })
 
     return (
         <div className={'carousel-grid carousel_container relative flex-1'}>
@@ -99,6 +45,9 @@ const Carousel = ({ slidesToShow, slidesToScroll, children }: CrouselProps) => {
                     className={
                         'grid grid-flow-col auto-cols-[minmax(200px,_1fr)] transition-transform duration-200'
                     }
+                    style={{
+                        transform: `translateX(-${currentTransitionX}px)`,
+                    }}
                 >
                     {childArray.map((child, idx) => (
                         <Carousel.Item key={idx} ref={carouselItemRef}>

--- a/src/components/ui/Carousel/Carousel.tsx
+++ b/src/components/ui/Carousel/Carousel.tsx
@@ -1,18 +1,9 @@
 'use client'
-import {
-    forwardRef,
-    useCallback,
-    useEffect,
-    useLayoutEffect,
-    useRef,
-    useState,
-} from 'react'
-import {
-    CarouselItemProps,
-    CrouselProps,
-    DEFAULT_OFFSET,
-} from '@/components/ui/Carousel/types'
+import { forwardRef } from 'react'
+import { CarouselItemProps, CrouselProps } from '@/components/ui/Carousel/types'
 import { useCarousel } from '@/components/ui/Carousel/useCarousel'
+import { RightArrow } from '@/components/Icons/RightArrow'
+import { LeftArrow } from '@/components/Icons/LeftArrow'
 
 /**
  *
@@ -43,7 +34,7 @@ const Carousel = ({ slidesToShow, slidesToScroll, children }: CrouselProps) => {
                 <ul
                     ref={carouselTrackRef}
                     className={
-                        'grid grid-flow-col auto-cols-[minmax(200px,_1fr)] transition-transform duration-200'
+                        'grid grid-flow-col auto-cols-[minmax(68px,_1fr)] transition-transform duration-200 gap-3'
                     }
                     style={{
                         transform: `translateX(-${currentTransitionX}px)`,
@@ -62,22 +53,13 @@ const Carousel = ({ slidesToShow, slidesToScroll, children }: CrouselProps) => {
                 }
                 onClick={handleOnPrev}
             >
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 32 32"
-                    width="12px"
-                    height="12px"
-                    aria-hidden="true"
-                    role="presentation"
-                    focusable="false"
-                >
-                    <path
-                        fill="none"
-                        d="M20 28 8.7 16.7a1 1 0 0 1 0-1.4L20 4"
-                        stroke="black"
-                        strokeWidth="5"
-                    ></path>
-                </svg>
+                <LeftArrow
+                    name={'leftArrow'}
+                    strokeWidth={5}
+                    stroke={'black'}
+                    width={12}
+                    height={12}
+                />
             </button>
             <button
                 className={
@@ -85,19 +67,12 @@ const Carousel = ({ slidesToShow, slidesToScroll, children }: CrouselProps) => {
                 }
                 onClick={handleOnNext}
             >
-                <svg
-                    width="12px"
-                    height="12px"
-                    viewBox="0 0 12 12"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                >
-                    <path
-                        d="M4.5 1.5L8.7375 5.7375C8.80621 5.8076 8.8447 5.90184 8.8447 6C8.8447 6.09816 8.80621 6.1924 8.7375 6.2625L4.5 10.5"
-                        stroke="black"
-                        strokeWidth="2"
-                    />
-                </svg>
+                <RightArrow
+                    name={'rightArrow'}
+                    strokeWidth={1}
+                    width={12}
+                    height={12}
+                />
             </button>
         </div>
     )

--- a/src/components/ui/Carousel/carousel.util.ts
+++ b/src/components/ui/Carousel/carousel.util.ts
@@ -1,0 +1,26 @@
+export const getGapStyle = (element: HTMLElement) => {
+    const computedStyle = getComputedStyle(element)
+    let gapValue = computedStyle.gap || computedStyle.columnGap || '0px'
+    if (gapValue === 'normal') gapValue = '0px'
+    return parseInt(gapValue)
+}
+
+export const getDefaultSlidesToShow = (
+    carouselTrackWidth: number,
+    individualSlideWidth: number
+): number => {
+    if (individualSlideWidth === 0 || carouselTrackWidth === 0)
+        throw new Error('zero division error')
+
+    return Math.floor(carouselTrackWidth / individualSlideWidth)
+}
+
+export const getDefaultSlidesToScroll = (
+    calculatedSlidesToShowFunction: () => number
+) => {
+    const SlideDeduction = -1
+    return Math.min(
+        calculatedSlidesToShowFunction() - SlideDeduction,
+        calculatedSlidesToShowFunction()
+    )
+}

--- a/src/components/ui/Carousel/index.ts
+++ b/src/components/ui/Carousel/index.ts
@@ -1,0 +1,3 @@
+import { Carousel } from './Carousel'
+export * from './types'
+export default Carousel

--- a/src/components/ui/Carousel/types.ts
+++ b/src/components/ui/Carousel/types.ts
@@ -1,0 +1,12 @@
+export type CarouselItemProps = {
+    children: React.ReactNode
+}
+
+export type CrouselProps = {
+    children: React.ReactNode | React.ReactNode[]
+    slidesToScroll?: number
+    slidesToShow?: number
+}
+
+export const DEFAULT_OFFSET = 1
+export const ZERO = 0

--- a/src/components/ui/Carousel/useCarousel.ts
+++ b/src/components/ui/Carousel/useCarousel.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { DEFAULT_OFFSET } from '@/components/ui/Carousel/types'
+
+type useCarouselProp = {
+    childArray: React.ReactNode[]
+    slidesToShow?: number
+    slidesToScroll?: number
+}
+export const useCarousel = ({
+    slidesToShow,
+    slidesToScroll,
+    childArray,
+}: useCarouselProp) => {
+    const [currentTransitionX, setCurrentTransitionX] = useState<number>(0)
+    const [calculatedSlidesToShow, setCalculatedSlidesToShow] =
+        useState<number>(0)
+    const [calculatedSlidesToScroll, setCalculatedSlidesToScroll] =
+        useState<number>(0)
+
+    const carouselTrackRef = useRef<HTMLUListElement>(null)
+    const carouselItemRef = useRef<HTMLLIElement>(null)
+    const individualSlideWidth = useRef<number>(0)
+
+    useEffect(() => {
+        if (carouselTrackRef.current && carouselItemRef.current) {
+            const carouselTrackWidth = carouselTrackRef.current.clientWidth
+            const computedStyle = getComputedStyle(carouselTrackRef.current)
+            let gapValue = computedStyle.gap || computedStyle.columnGap || '0px'
+
+            if (gapValue === 'normal') gapValue = '0px'
+            individualSlideWidth.current =
+                carouselItemRef.current.clientWidth + parseInt(gapValue)
+
+            const calculatedSlidesToShow =
+                slidesToShow ||
+                Math.floor(carouselTrackWidth / individualSlideWidth.current)
+
+            const getDefaultSlidesToScroll =
+                calculatedSlidesToShow > 2
+                    ? calculatedSlidesToShow - 1
+                    : calculatedSlidesToShow
+
+            const calculatedSlidesToScroll =
+                slidesToScroll || getDefaultSlidesToScroll
+
+            setCalculatedSlidesToShow(calculatedSlidesToShow)
+            setCalculatedSlidesToScroll(calculatedSlidesToScroll)
+        }
+    }, [slidesToScroll, slidesToShow, currentTransitionX])
+
+    const handleOnPrev = useCallback(() => {
+        if (!carouselTrackRef.current) {
+            console.warn('carouselTrackRef is not defined')
+            return
+        }
+
+        setCurrentTransitionX((prev) => {
+            const nextPosition =
+                prev - calculatedSlidesToScroll * individualSlideWidth.current
+            return Math.max(0, nextPosition)
+        })
+    }, [calculatedSlidesToShow])
+
+    const handleOnNext = useCallback(() => {
+        if (!carouselTrackRef.current) {
+            console.warn('carouselTrackRef is not defined')
+            return
+        }
+
+        const maxScrollPosition =
+            childArray.length * individualSlideWidth.current -
+            carouselTrackRef.current.clientWidth
+
+        setCurrentTransitionX((prev) => {
+            const nextPosition =
+                prev + calculatedSlidesToScroll * individualSlideWidth.current
+            return Math.min(nextPosition, maxScrollPosition)
+        })
+    }, [calculatedSlidesToScroll, childArray.length])
+
+    return {
+        handleOnPrev,
+        handleOnNext,
+        carouselTrackRef,
+        carouselItemRef,
+        currentTransitionX,
+        calculatedSlidesToShow,
+        calculatedSlidesToScroll,
+    }
+}

--- a/src/components/ui/SVGIcon/SVGIcon.tsx
+++ b/src/components/ui/SVGIcon/SVGIcon.tsx
@@ -1,0 +1,24 @@
+import { SVGProps } from 'react'
+import { SVGIconProps } from '@/components/ui/SVGIcon/types'
+
+export const SVGIcon = ({
+    name,
+    width,
+    height,
+    size,
+    viewBox,
+    children,
+    ...props
+}: SVGIconProps) => {
+    return (
+        <svg
+            xmlns={'https://www.w3.org/2000/svg'}
+            viewBox={viewBox || '0 0 24 24'}
+            width={size || width || 24}
+            height={size || height || 24}
+            {...props}
+        >
+            {children}
+        </svg>
+    )
+}

--- a/src/components/ui/SVGIcon/index.ts
+++ b/src/components/ui/SVGIcon/index.ts
@@ -1,0 +1,2 @@
+export * from './SVGIcon'
+export * from './types'

--- a/src/components/ui/SVGIcon/types.ts
+++ b/src/components/ui/SVGIcon/types.ts
@@ -1,0 +1,10 @@
+import { SVGProps } from 'react'
+
+export interface SVGIconProps extends SVGProps<SVGSVGElement> {
+    name: string
+    size?: number
+    viewBox?: string
+    width?: number
+    height?: number
+    children?: React.ReactNode
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -76,9 +76,41 @@ const config = {
             backgroundImage: {
                 'hero-pattern': 'var(--gradient)',
             },
+            gridTemplateColumns: {
+                carousel: 'auto 1fr auto',
+            },
+            gridTemplateAreas: {
+                carousel: [
+                    'carousel_prev_btn carousel_container carousel_next_btn',
+                ],
+            },
         },
     },
-    plugins: [require('tailwindcss-animate')],
+    plugins: [
+        require('tailwindcss-animate'),
+        function ({
+            addUtilities,
+        }: {
+            addUtilities: (utilities: Record<string, any>) => void
+        }) {
+            addUtilities({
+                '.grid-areas-carousel': {
+                    'grid-template-areas': `
+            "carousel_prev_btn carousel_container carousel_next_btn"
+          `,
+                },
+                '.area-carousel_prev_btn': {
+                    'grid-area': 'carousel_prev_btn',
+                },
+                '.area-carousel_container': {
+                    'grid-area': 'carousel_container',
+                },
+                '.area-carousel_next_btn': {
+                    'grid-area': 'carousel_next_btn',
+                },
+            })
+        },
+    ],
 } satisfies Config
 
 export default config


### PR DESCRIPTION
## PR Title
카테고리 UI 및 이미지 Carousel 공통 컴포넌트 작업 #32  연장선 

## Implementation Details and Changes

### 1. useCarousel 커스텀 훅 추가 
- SlideToScroll, SlidsToShow 가 없을 경우, 현재 뷰포트에 확인된 슬라이드의 개수를 통해 default 계산 
- max, min 을 이용하여  마지막 아이콘은 항상 뷰포트의 가장 오른쪽에 위치


### 2. Flex -> Grid 변경

- 버튼과 Slider 간의 배치에서 Grid 가 깔끔 
- 리사이징시 Flex는 전체 슬라이드 리스트도 같이 리사이징 되는 문제 -> airbnb 요구사항  ❌
- tailwind 커스텀 유틸리티 함수 추가 

###  3. SVG 공통 컴포넌트
-  `src/ui/SVGIcon` :  각각의 아이콘 컴포넌트에 재사용 될 베이스 컴포넌트 
-  `src/components/Icons/*` 컴포넌트로 관리되는 각 svg icon 경로 

>🤔  svg컴포넌트를 하나씩 만드려니  불편해서 [svgr](https://react-svgr.com/) 이나 [svg-sprite-loader](https://www.npmjs.com/package/svg-sprite-loader) 사용 하는 걸 고려하는데 혹시 추천하실 만한거 있으신가요? 



## Related Issues
- [ ] Closes #31   