### PR TITLE
Feature/42 tab zustand

### DIFF
--- a/src/components/ui/BaseTabs/BaseTabs.tsx
+++ b/src/components/ui/BaseTabs/BaseTabs.tsx
@@ -12,7 +12,7 @@ import { useTabStore } from '@/store/ui/useTabStore'
 //개선하고 싶은 부분 : BaseTabs에 제네릭으로 받은 T - value를 하위 컴포넌트에서 제한된 T 로 좁혀지게 사용하도록?;
 
 const BaseTabs = (
-    { tabValues, children }: BaseTabsProps,
+    { children }: BaseTabsProps,
     ref: React.Ref<HTMLDivElement>
 ) => {
     return <>{children}</>

--- a/src/components/ui/BaseTabs/BaseTabs.tsx
+++ b/src/components/ui/BaseTabs/BaseTabs.tsx
@@ -1,6 +1,5 @@
 'use client'
-import React, { useContext, useMemo } from 'react'
-import BaseTabsContext from './BaseTabsContext'
+import React from 'react'
 import {
     BaseTabsContentProps,
     BaseTabsProps,
@@ -8,39 +7,32 @@ import {
     BaseTabsListProps,
 } from './BaseTabs.types'
 import clsx from 'clsx'
+import { useTabStore } from '@/store/ui/useTabStore'
 
 //개선하고 싶은 부분 : BaseTabs에 제네릭으로 받은 T - value를 하위 컴포넌트에서 제한된 T 로 좁혀지게 사용하도록?;
 
-const BaseTabs = <T extends string>(
-    { children }: BaseTabsProps<T>,
+const BaseTabs = (
+    { tabValues, children }: BaseTabsProps,
     ref: React.Ref<HTMLDivElement>
 ) => {
-    const [activeItem, setActiveItem] = React.useState('')
-    return (
-        <BaseTabsContext.Provider
-            value={useMemo(() => ({ activeItem, setActiveItem }), [activeItem])}
-        >
-            {children}
-        </BaseTabsContext.Provider>
-    )
+    return <>{children}</>
 }
 
-const BaseTabsTrigger = <T extends string>({
+const BaseTabsTrigger = ({
     value,
     children,
     activeClassName,
     ...props
-}: BaseTabsTriggerProps<T>) => {
-    const { activeItem, setActiveItem } = useContext(BaseTabsContext)
+}: BaseTabsTriggerProps) => {
+    const { selectedTab, setSelectedTab } = useTabStore()
     const handleBaseTabsTrigger = () => {
-        console.log('value', value, activeItem)
-        if (value === activeItem) return
-        setActiveItem(value)
+        if (value === selectedTab) return
+        setSelectedTab(value)
     }
     return (
         <button
             {...props}
-            className={clsx(activeItem === value && activeClassName)}
+            className={clsx(selectedTab === value && activeClassName)}
             onClick={handleBaseTabsTrigger}
         >
             {children}
@@ -56,13 +48,13 @@ const BaseTabsList = ({ children, ...props }: BaseTabsListProps) => {
     )
 }
 
-const BaseTabsContent = <T extends string>({
+const BaseTabsContent = ({
     value,
     children,
     ...props
-}: BaseTabsContentProps<T>) => {
-    const { activeItem } = useContext(BaseTabsContext)
-    return activeItem === value ? <div {...props}>{children}</div> : null
+}: BaseTabsContentProps) => {
+    const { selectedTab } = useTabStore()
+    return selectedTab === value ? <div {...props}>{children}</div> : null
 }
 
 BaseTabs.Trigger = BaseTabsTrigger

--- a/src/components/ui/BaseTabs/BaseTabs.types.ts
+++ b/src/components/ui/BaseTabs/BaseTabs.types.ts
@@ -2,7 +2,6 @@
 
 export type BaseTabsProps = {
     defaultActiveItem?: string //TODO : T에서 중 한가지여야 함
-    tabValues: string[]
     children: React.ReactNode
 } & Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>
 

--- a/src/components/ui/BaseTabs/BaseTabs.types.ts
+++ b/src/components/ui/BaseTabs/BaseTabs.types.ts
@@ -1,21 +1,20 @@
-'use client'
 // children 을 직접 받는 컴포넌트를 만들 때는 chidlren 타입 제외하고 직접 children을 받는다.
 
-export type BaseTabsProps<T> = {
+export type BaseTabsProps = {
     defaultActiveItem?: string //TODO : T에서 중 한가지여야 함
-    children: React.ReactNode | React.ReactNode[]
+    tabValues: string[]
+    children: React.ReactNode
 } & Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>
 
-export type CommonBaseTabsProps<T extends string> = Readonly<{
-    value: T
-    children: React.ReactNode
-}>
+export type BaseTabsTriggerProps = {
+    value: string
+    activeClassName?: string
+} & React.ButtonHTMLAttributes<HTMLButtonElement>
 
-export type BaseTabsTriggerProps<T extends string> = CommonBaseTabsProps<T> &
-    React.ButtonHTMLAttributes<HTMLButtonElement> & { activeClassName?: string }
-
-export type BaseTabsContentProps<T extends string> = CommonBaseTabsProps<T> &
-    React.HTMLAttributes<HTMLDivElement>
+export type BaseTabsContentProps = {
+    value: string
+    activeClassName?: string
+} & React.HTMLAttributes<HTMLDivElement>
 
 export type BaseTabsListProps = Readonly<{ children: React.ReactNode }> &
     React.HTMLAttributes<HTMLDivElement>

--- a/src/components/ui/Popover/index.ts
+++ b/src/components/ui/Popover/index.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export { Popover } from './Popover'

--- a/src/features/search/components/DateChooserTabs/index.tsx
+++ b/src/features/search/components/DateChooserTabs/index.tsx
@@ -1,0 +1,51 @@
+import { BaseTabs } from '@/components/ui/BaseTabs/BaseTabs'
+import { RangeCalendar } from '@/features/search/components/RangeCalendar'
+
+export const DateChooserTabs = () => {
+    return (
+        <BaseTabs>
+            <BaseTabs.List
+                className={
+                    'grid grid-cols-auto-fit mx-auto bg-airbnb-neutral-300 px-4 py-2 rounded-3xl gap-x-8'
+                }
+            >
+                <BaseTabs.Trigger
+                    value="dates"
+                    className={'px-4 py-2'}
+                    activeClassName={'bg-airbnb-neutral-100 rounded-3xl px-2'}
+                >
+                    날짜지정
+                </BaseTabs.Trigger>
+                <BaseTabs.Trigger
+                    value="months"
+                    className={'px-4 py-2 gap-2'}
+                    activeClassName={'bg-airbnb-neutral-100 rounded-3xl px-2'}
+                >
+                    월단위
+                </BaseTabs.Trigger>
+                <BaseTabs.Trigger
+                    value="flexible"
+                    className={'px-4 py-2'}
+                    activeClassName={'bg-airbnb-neutral-100 rounded-3xl px-2'}
+                >
+                    유연한 일정
+                </BaseTabs.Trigger>
+            </BaseTabs.List>
+            {
+                <BaseTabs.Content value="dates">
+                    <RangeCalendar />
+                </BaseTabs.Content>
+            }
+            {
+                <BaseTabs.Content value="months">
+                    <h1>months</h1>
+                </BaseTabs.Content>
+            }
+            {
+                <BaseTabs.Content value="flexible">
+                    <h1>flexible</h1>
+                </BaseTabs.Content>
+            }
+        </BaseTabs>
+    )
+}

--- a/src/features/search/components/LocationSearchContent/index.tsx
+++ b/src/features/search/components/LocationSearchContent/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import Image from 'next/image'
 const searchWithLocation = [
@@ -33,36 +35,40 @@ const DOMESTIC_CITIES = {
 
 type CITY_KEY = keyof typeof DOMESTIC_CITIES
 
-export default function PlaceInputComponent() {
+export const LocationSearchContent = () => {
     return (
-        <div className="popover overflow-hidden rounded-xl px-3">
+        <div className={'popover overflow-hidden rounded-xl px-3'}>
             <h4>지역으로 검색하기</h4>
-            <div className="grid grid-cols-card-grid gap-2">
+            <div className={'grid grid-cols-card-grid gap-2'}>
                 {searchWithLocation.map((item, index) => (
-                    <button key={item.text} className="card">
-                        <div className="card-icon s">
+                    <button key={item.text} className={'card'}>
+                        <div className={'card-icons'}>
                             <Image
                                 src={`/images/${item.icon}.png`}
                                 alt={item.text}
                                 width={81}
                                 height={81}
-                                className="border-solid border-2 border-gray-300 rounded-2xl"
+                                className={
+                                    'border-solid border-2 border-gray-300 rounded-2xl'
+                                }
                             />
                         </div>
-                        <div className="card-text">{item.text}</div>
+                        <div className={'card-text'}>{item.text}</div>
                     </button>
                 ))}
             </div>
 
             <h4>한국</h4>
-            <div className=" grid grid-cols-card-grid gap-3">
+            <div className={'grid grid-cols-card-grid gap-3'}>
                 {(Object.keys(DOMESTIC_CITIES) as CITY_KEY[]).map(
                     (cityKey, idx) => (
                         <div
                             key={cityKey}
-                            className="relative border border-solid border-gray-400 rounded-xl px-5 py-1 text-center cursor-pointer"
+                            className={
+                                'relative border border-solid border-gray-400 rounded-xl px-5 py-1 text-center cursor-pointer'
+                            }
                         >
-                            <button className=" w-full">
+                            <button className={'w-full'}>
                                 {DOMESTIC_CITIES[cityKey]}
                             </button>
                         </div>

--- a/src/features/search/components/RangeCalendar/index.tsx
+++ b/src/features/search/components/RangeCalendar/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
+import { useSearchStore } from '@/store/useSearchStore'
 import React from 'react'
 import { DayPicker } from 'react-day-picker'
-import { useSearchStore } from '../../store/searchStore'
 
 type Props = {}
 

--- a/src/features/search/components/RangeCalendar/index.tsx
+++ b/src/features/search/components/RangeCalendar/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useSearchStore } from '@/store/useSearchStore'
 import React from 'react'
 import { DayPicker } from 'react-day-picker'
+import { useSearchStore } from '@/store/useSearchStore'
 
 type Props = {}
 

--- a/src/features/search/components/SearchButton/index.tsx
+++ b/src/features/search/components/SearchButton/index.tsx
@@ -1,0 +1,16 @@
+'use client'
+import Search from '@/components/Icons/Search'
+
+export const SearchButton = () => {
+    return (
+        <div>
+            <button
+                className={
+                    'flex justify-center items-center w-12 h-12 rounded-full bg-rose-600 mr-4'
+                }
+            >
+                <Search width={14} height={14} />
+            </button>
+        </div>
+    )
+}

--- a/src/features/search/components/SearchPopoverInput/index.tsx
+++ b/src/features/search/components/SearchPopoverInput/index.tsx
@@ -1,0 +1,40 @@
+'use client'
+import React from 'react'
+import SearchInputLayout from '../../layouts/SearchInputLayout'
+import { Popover } from '@/components/ui/Popover'
+
+type SearchPopoverInputProps = {
+    width: string
+    label?: string
+    value?: string
+    placeholder?: string
+    contents?: React.ReactNode
+}
+
+export const SearchPopoverInput = ({
+    width,
+    label,
+    value,
+    placeholder,
+    contents,
+}: SearchPopoverInputProps) => {
+    return (
+        <SearchInputLayout width={width}>
+            <Popover>
+                <Popover.Trigger>
+                    <div className={'border-r border-r-gray-200'}>
+                        <label>
+                            {label}
+                            <input
+                                type={'text'}
+                                placeholder={placeholder}
+                                value={value}
+                            />
+                        </label>
+                    </div>
+                </Popover.Trigger>
+                {contents && <Popover.Content>{contents}</Popover.Content>}
+            </Popover>
+        </SearchInputLayout>
+    )
+}

--- a/src/features/search/components/SearchTabs/index.tsx
+++ b/src/features/search/components/SearchTabs/index.tsx
@@ -1,13 +1,11 @@
 'use client'
-import PlaceInputComponent from '@/features/search/components/PlaceInputComponent'
-import { BaseTabs } from '@/components/ui/BaseTabs'
-import { RangeCalendar } from '@/features/search/components/RangeCalendar'
 import SearchTabsWrapperLayout from '../../layouts/SearchTabsWrapperLayout'
-import SearchInputLayout from '../../layouts/SearchInputLayout'
 import { format } from 'date-fns'
-import { Search } from '@/components/Icons'
 import { useSearchStore } from '@/store/useSearchStore'
-import { Popover } from '@/components/ui/Popover/Popover'
+import { DateChooserTabs } from '@/features/search/components/DateChooserTabs'
+import { SearchButton } from '../SearchButton'
+import { LocationSearchContent } from '@/features/search/components/LocationSearchContent'
+import { SearchPopoverInput } from '../SearchPopoverInput'
 
 /**
  * SearchTabs
@@ -19,137 +17,40 @@ export const SearchTabs = () => {
 
     return (
         <SearchTabsWrapperLayout>
-            {/* ======== Place ================== */}
-            <SearchInputLayout width="w-2/6">
-                <Popover>
-                    <Popover.Trigger>
-                        <div className={'border-r border-r-gray-200'}>
-                            <label>
-                                여행지
-                                <input
-                                    type="text"
-                                    placeholder={'여행지 검색'}
-                                    value={destination}
-                                />
-                            </label>
-                        </div>
-                    </Popover.Trigger>
-                    <Popover.Content>
-                        <PlaceInputComponent />
-                    </Popover.Content>
-                </Popover>
-            </SearchInputLayout>
-            {/* ======== CheckIn, CheckOut ======== */}
-            <SearchInputLayout width="w-1/6">
-                <Popover>
-                    <Popover.Trigger>
-                        <div className={'border-r border-r-gray-200'}>
-                            <label>
-                                체크인
-                                <input
-                                    type="text"
-                                    placeholder={'날짜 추가'}
-                                    value={from ? format(from, 'M월dd일') : ''}
-                                />
-                            </label>
-                        </div>
-                    </Popover.Trigger>
-                    <Popover.Content>
-                        <BaseTabs>
-                            <BaseTabs.List
-                                className={
-                                    'grid grid-cols-auto-fit mx-auto bg-airbnb-neutral-300 px-4 py-2 rounded-3xl gap-x-8'
-                                }
-                            >
-                                <BaseTabs.Trigger
-                                    value="dates"
-                                    className={'px-4 py-2'}
-                                    activeClassName={
-                                        'bg-airbnb-neutral-100 rounded-3xl px-2'
-                                    }
-                                >
-                                    날짜지정
-                                </BaseTabs.Trigger>
-                                <BaseTabs.Trigger
-                                    value="months"
-                                    className={' px-4 py-2 gap-2'}
-                                    activeClassName={
-                                        'bg-airbnb-neutral-100 rounded-3xl px-2'
-                                    }
-                                >
-                                    월단위
-                                </BaseTabs.Trigger>
-                                <BaseTabs.Trigger
-                                    value="flexible"
-                                    className={' px-4 py-2'}
-                                    activeClassName={
-                                        'bg-airbnb-neutral-100 rounded-3xl px-2'
-                                    }
-                                >
-                                    유연한 일정
-                                </BaseTabs.Trigger>
-                            </BaseTabs.List>
-                            {
-                                <BaseTabs.Content value="dates">
-                                    <RangeCalendar />
-                                </BaseTabs.Content>
-                            }
-                            {
-                                <BaseTabs.Content value="months">
-                                    <h1>months</h1>
-                                </BaseTabs.Content>
-                            }
-                            {
-                                <BaseTabs.Content value="flexible">
-                                    <h1>flexible</h1>
-                                </BaseTabs.Content>
-                            }
-                        </BaseTabs>
-                    </Popover.Content>
-                </Popover>
-            </SearchInputLayout>
-            <SearchInputLayout width="w-2/6">
-                <Popover>
-                    <Popover.Trigger>
-                        <div className={'border-r border-r-gray-200'}>
-                            <label>
-                                체크아웃
-                                <input
-                                    type="text"
-                                    placeholder={'날짜 추가'}
-                                    value={to ? format(to, 'M월dd일') : ''}
-                                />
-                            </label>
-                        </div>
-                    </Popover.Trigger>
-                </Popover>
-            </SearchInputLayout>
-            {/* ======== Number of Guests ======== */}
-            <SearchInputLayout width="w-2/6">
-                <Popover>
-                    <Popover.Trigger>
-                        <div>
-                            <label>여행자</label>
-                            <input placeholder={'게스트 추가'} />
-                        </div>
-                    </Popover.Trigger>
-                    <Popover.Content>
-                        <div className="popover">
-                            <h3>Popover</h3>
-                            <p>Popover content</p>
-                        </div>
-                    </Popover.Content>
-                </Popover>
-            </SearchInputLayout>
-            <div>
-                <button
-                    className={
-                        'flex justify-center items-center w-12 h-12 rounded-full bg-rose-600 mr-4 '
-                    }
-                >
-                    <Search width={14} height={14} />
-                </button>
-            </div>
+            <SearchPopoverInput
+                width="w-2/6"
+                label="여행지"
+                value={destination}
+                placeholder="여행지 검색"
+                contents={<LocationSearchContent />}
+            />
+
+            <SearchPopoverInput
+                width="w-1/6"
+                label="체크인"
+                value={from ? format(from, 'M월dd일') : ''}
+                placeholder="날짜 추가"
+                contents={<DateChooserTabs />}
+            />
+            <SearchPopoverInput
+                width="w-2/6"
+                label="체크아웃"
+                placeholder="날짜 추가"
+                value={to ? format(to, 'M월dd일') : ''}
+            />
+            <SearchPopoverInput
+                width="w-2/6"
+                label="여행자"
+                placeholder="게스트 추가"
+                contents={
+                    <div className="popover">
+                        <h3>Popover</h3>
+                        <p>Popover content</p>
+                    </div>
+                }
+            />
+
+            <SearchButton />
         </SearchTabsWrapperLayout>
     )
 }

--- a/src/features/search/components/SearchTabs/index.tsx
+++ b/src/features/search/components/SearchTabs/index.tsx
@@ -1,20 +1,18 @@
 'use client'
-import Popover from '../../../../components/ui/Popover/Popover'
 import PlaceInputComponent from '@/features/search/components/PlaceInputComponent'
 import { BaseTabs } from '@/components/ui/BaseTabs'
 import { RangeCalendar } from '@/features/search/components/RangeCalendar'
 import SearchTabsWrapperLayout from '../../layouts/SearchTabsWrapperLayout'
 import SearchInputLayout from '../../layouts/SearchInputLayout'
-import { useSearchStore } from '../../store/searchStore'
 import { format } from 'date-fns'
 import { Search } from '@/components/Icons'
+import { useSearchStore } from '@/store/useSearchStore'
+import { Popover } from '@/components/ui/Popover/Popover'
 
 /**
  * SearchTabs
  * @constructor
  */
-
-type TabValue = 'dates' | 'months' | 'flexible'
 
 export const SearchTabs = () => {
     const { destination, from, to } = useSearchStore()
@@ -57,7 +55,7 @@ export const SearchTabs = () => {
                         </div>
                     </Popover.Trigger>
                     <Popover.Content>
-                        <BaseTabs<TabValue>>
+                        <BaseTabs>
                             <BaseTabs.List
                                 className={
                                     'grid grid-cols-auto-fit mx-auto bg-airbnb-neutral-300 px-4 py-2 rounded-3xl gap-x-8'

--- a/src/store/ui/useTabStore.ts
+++ b/src/store/ui/useTabStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+type TabStore = {
+    selectedTab: string
+    setSelectedTab: (selectedTab: string) => void
+}
+
+export const useTabStore = create<TabStore>((set) => ({
+    selectedTab: '',
+    setSelectedTab: (selectedTab: string) => set({ selectedTab }),
+}))


### PR DESCRIPTION
## 📝 PR 설명
close #42  
<!-- 이 PR의 목적과 변경 사항을 간략히 설명해주세요. -->
1. 이전 코드리뷰를 반영하여 공통 컴포넌트 Tabs에 ContextAPI -> zustand 상태관리 적용  
2. 컴포넌트 리팩토링 작업 : SearchTabs 컴포넌트 내 각Tab에 해당되는 컴포넌트 들이  펼쳐진 상태로 표현되어 오히려 컴포넌트가 비대해지고 복잡해 지는 문제 -> 가독성에 좋지 않았습니다. 이 컴포넌트가 어떤 것을 보여주고 싶은지 한눈에 보기 어려웠습니다. 

## 🛠 변경 사항

<!-- 주요 변경 사항을 bullet point로 나열해주세요. -->

-  공통컴포넌트 Tabs의  ContextAPI 로 상태 공유에서  useTabStore 전역 상태 관리 툴을 통해 상태 관리  
-  SearchTabs 에  각각의 탭 (지역선택, 출발일, 도착일, 인원 선택  ) 을 담당하는 컴포넌트를 리팩토링 했습니다.

https://github.com/f-lab-edu/airbnb-clone/blob/370e1d9ecda66a99aa8d88b15af6d4736d54ff6c/src/features/search/components/SearchTabs/index.tsx#L19-L54
https://github.com/f-lab-edu/airbnb-clone/blob/370e1d9ecda66a99aa8d88b15af6d4736d54ff6c/src/features/search/components/SearchPopoverInput/index.tsx#L14-L40


## 🤔 고민한 점

<!-- 구현 과정에서 고민했던 부분이나 의사 결정 과정을 설명해주세요. -->

- 공통 컴포넌트의 경우는 Compound Pattern을 사용할 땐 ContextAPI의 틀을 유지하기 위해 Provider를 세팅하고 부가적인 작업들이 있었는데, zustand를 적용하고 난 후 그런것들이 사라지니 코드가 간결해 졌습니다. 

- **리팩토링 전 문제점 :** 
    -  각 검색 입력 필드(여행지, 체크인, 체크아웃, 여행자)가 비슷한 구조로 반복되고 있었습니다. 게다가 각각Popover,  Tab, label, input 등을 포함하고 있어 코드 중복이 많았습니다.

- **해결 :**
   - 늘어진 코드들을 SearchPopoverInput 로 한단계 추상화 시켰습니다. 
   - 추상화 할 때 고려한 부분은 
  1.  네이밍에서 어떤 형태,기능의 컴포넌트인지 ( input이면서 popover되는 컴포넌트)가 직관적으로 드러나게 정했으며,   
  2. 각 탭의 역할(예: 여행지 선택, 날짜 선택 등)을 명확히 파악할 수 있도록, props인 input label과 popover에 표시될 컨텐츠로 정의했습니다.



## 📚 참고 자료

<!-- 참고한 문서, 튜토리얼, 스택오버플로우 등의 링크를 추가해주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 사항들을 체크해주세요. -->

## 👀 스크린샷 (선택사항)

<!-- UI 변경사항이 있다면 스크린샷을 추가해주세요. -->

## 🙋‍♂️ 멘토에게 묻고 싶은 점

<!-- 멘토에게 특별히 물어보고 싶은 점이나 피드백을 받고 싶은 부분을 작성해주세요. -->
- 멘토님 실무에서 따로 지키는 컨벤션이 있다면 어떤 것들이 있을까요? 
- 가능하다면 프로젝트에 저도 컨벤션을 적용해 보고 싶어요. 의견 궁금합니다. 